### PR TITLE
Check for and warn users if the ANDROID_HOME environment variable is not set on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ Copy the Gemfile to the directory where you want to keep your Calabash tests and
 
 You must first have [Ruby installed](http://rubyinstaller.org/) along with the RubyInstaller DevKit installed. Once you have this done, download the Powershell script `install-calabash-local-windows.ps1` and run it using Powershell.
 
+You must also have the Android SDK installed and the `ANDROID_HOME` environment variable set.

--- a/install-calabash-local-windows.ps1
+++ b/install-calabash-local-windows.ps1
@@ -1,9 +1,25 @@
 Write-Host ' '
 Write-Host 'Installing Calabash on Windows:'
+Write-Host " "
 
 # STEP 1: Check the version of Ruby installed.
 $result = & "ruby" "-v"
 Write-Host "  Ruby version installed: " $result
+Write-Host "  "
+
+# STEP 2: Perform a quick check to see if the Android SDK is installed
+$androidHome = "$env:ANDROID_HOME"
+if ([String]::IsNullOrWhiteSpace($androidHome)) 
+{
+	Write-Host "  Could not not detect the Android SDK. Please ensure that it is installed"
+	Write-Host "  and that the ANDROID_HOME environment variable is set."
+}
+else 
+{
+	Write-Host "  "
+	Write-Host "  Detected the Android SDK at $androidHome."
+}
+Write-Host "  "
 
 $calabashDir = "$env:USERPROFILE\calabash\"
 if (Test-Path $calabashDir)
@@ -15,12 +31,12 @@ if (Test-Path $calabashDir)
 }
 else 
 {
-	# STEP 2: Create the Calabash directory.
+	# STEP 3: Create the Calabash directory.
 	Write-Host "  Creating the Calabash directory at $calabashDir."	
 	New-Item $calabashDir -ItemType directory | Out-Null
 	Write-Host " "
 
-	# STEP 3: Download the SSL Certificate and set the SSL_CERT_FILE 
+	# STEP 4: Download the SSL Certificate and set the SSL_CERT_FILE 
 	# environment variable for the process.
 	$cacertFile = "$calabashDir\cacert.pem"
 	Write-Host "  Downloading SSL certificate to $cacertFile."
@@ -32,12 +48,12 @@ else
 	[Environment]::SetEnvironmentVariable("SSL_CERT_FILE", $cacertFile, "process")
 	Write-Host " "
 
-	# STEP 4: Update the version of RubyGems 
+	# STEP 5: Update the version of RubyGems 
 	Write-Host "  Performing a system update of RubyGems:"
 	& "gem" "update" "--system"
 	Write-Host " "
 
-	# STEP 5: Install the gems
+	# STEP 6: Install the gems
 	Write-Host "    Installing ffi..."
 	& "gem" "install" "ffi" "--platform=ruby" "--no-ri" "--no-rdoc"
 	Write-Host " "


### PR DESCRIPTION
Based docs issue [510](https://github.com/xamarin/documentation/issues/510) and other feedback, `calabash-android` needs the `ANDROID_HOME` environment variable to be set (on Windows).