### PR TITLE
Windows: Use existing calabash user dir and default ssl cert dir

### DIFF
--- a/install-calabash-local-windows.ps1
+++ b/install-calabash-local-windows.ps1
@@ -1,28 +1,5 @@
 Param([switch]$ReplaceCalabashUserFiles)
 
-Function Remove-Directory([string]$DirectoryToRemove)
-{
-    if (Test-Path $DirectoryToRemove)
-    {
-        if (!($ReplaceCalabashUserFiles))
-        {
-            do {
-                $deleteDir = Read-Host "The directory $DirectoryToRemove already exists.  Do you want to delete it? (Y | N)"
-                if ($deleteDir -eq "N")
-                {
-                    Write-Host "  Unable to continue, exiting."
-                    Return $False
-                }
-            
-            } while ($deleteDir -notmatch "[Y]")
-        }
-
-        Remove-Item -Recurse -Force $DirectoryToRemove
-    }
-
-    Return $True
-}
-
 Write-Host ' '
 Write-Host 'Installing Calabash on Windows:'
 Write-Host " "
@@ -46,7 +23,7 @@ else
 Write-Host "  "
 
 # STEP 3: Create the Calabash directory if required.
-$calabashDir = "$env:USERPROFILE\calabash"
+$calabashDir = "$env:USERPROFILE\.calabash"
 if (!(Test-Path $calabashDir)) 
 {
 	Write-Host "  Creating the Calabash directory at $calabashDir."	
@@ -54,52 +31,36 @@ if (!(Test-Path $calabashDir))
 	Write-Host " "
 }
 
-# STEP 4: Removing any existing Certificates directory.
-$cacertDir = "$calabashDir\certs"
-if (!(Remove-Directory -DirectoryToRemove $cacertDir))
+# STEP 4: Get the SSL certificates directory
+$rubygems = iex "gem which rubygems"
+if (!($rubygems.EndsWith("rubygems.rb")))
 {
+    Write-Host " "
+    Write-Host "  Unable to locate rubygems install directory!  Exiting..."
+    Write-Host " "
     Exit
 }
+$rubygemsDir = $rubygems.Substring(0, $rubygems.Length - 3)
+$sslCertsDir = "$rubygemsDir\ssl_certs"
 
-# STEP 5: Create a new Certificates directory.
-Write-Host "  Creating the Calabash cert directory at $cacertDir."	
-New-Item $cacertDir -ItemType directory | Out-Null
-Write-Host " "
-
-# STEP 6: Download the SSL Certificate and set the SSL_CERT_FILE 
-# environment variable for the process.
-$cacertFile = "$cacertDir\cacert.pem"
-Write-Host "  Downloading SSL certificate to $cacertFile."
-Invoke-WebRequest 'http://curl.haxx.se/ca/cacert.pem' -OutFile $cacertFile
-Write-Host " "
-
-Write-Host "  Set the environment variable SSL_CERT_FILE=$cacertFile."
-[Environment]::SetEnvironmentVariable("SSL_CERT_FILE", $cacertFile, "user")
-[Environment]::SetEnvironmentVariable("SSL_CERT_FILE", $cacertFile, "process")
-Write-Host " "
-
-# STEP 7: Remove any existing Gems directory.
-$gemsDir = "$calabashDir\gems"
-if (!(Remove-Directory -DirectoryToRemove $gemsDir))
+# STEP 5: Download the SSL Certificate if required.
+$cacertFile = "$sslCertsDir\AddTrustExternalCARoot.pem"
+if (!(Test-Path $cacertFile))
 {
-    Exit
+    Write-Host "  Downloading SSL certificate to $cacertFile."
+    Invoke-WebRequest 'https://github.com/rubygems/rubygems/raw/master/lib/rubygems/ssl_certs/AddTrustExternalCARoot.pem' -OutFile $cacertFile
+    Write-Host " "
 }
 
-# STEP 8: Create the Gems directory.
-Write-Host "  Creating the Calabash gems directory at $gemsDir."
-New-Item $gemsDir -ItemType directory | Out-Null
-Write-Host " "
-
-# STEP 9: Update the version of RubyGems 
+# STEP 6: Update the version of RubyGems 
 Write-Host "  Performing a system update of RubyGems:"
 & "gem" "update" "--system"
 Write-Host " "
 
-# STEP 10: set the GEN_HOME and GEN_PATH environment variables.
-$Env:GEM_HOME = $gemsDir;
-$Env:GEM_PATH = $gemsDir;
+# STEP 7: Install the gems
+Write-Host "  Installing Calabash... This could take a few minutes"
+Write-Host " "
 
-# STEP 11: Install the gems
 Write-Host "    Installing xamarin-test-cloud..."
 & "gem" "install" "xamarin-test-cloud" "--platform=ruby"  "--no-document"
 Write-Host " "
@@ -108,4 +69,10 @@ Write-Host "    Installing calabash-android..."
 & "gem" "install" "calabash-android" "--platform=ruby"  "--no-document"
 Write-Host " "
 
-Write-Host "Finished installing Calabash on Windows."
+Write-Host "Done Installing!"
+Write-Host " "
+Write-Host "You can always uninstall using:"
+Write-Host " "
+Write-Host "  gem uninstall xamarin-test-cloud"
+Write-Host "  gem uninstall calabash-android"
+

--- a/install-calabash-local-windows.ps1
+++ b/install-calabash-local-windows.ps1
@@ -1,5 +1,3 @@
-Param([switch]$ReplaceCalabashUserFiles)
-
 Write-Host ' '
 Write-Host 'Installing Calabash on Windows:'
 Write-Host " "

--- a/install-calabash-local-windows.ps1
+++ b/install-calabash-local-windows.ps1
@@ -1,3 +1,28 @@
+Param([switch]$ReplaceCalabashUserFiles)
+
+Function Remove-Directory([string]$DirectoryToRemove)
+{
+    if (Test-Path $DirectoryToRemove)
+    {
+        if (!($ReplaceCalabashUserFiles))
+        {
+            do {
+                $deleteDir = Read-Host "The directory $DirectoryToRemove already exists.  Do you want to delete it? (Y | N)"
+                if ($deleteDir -eq "N")
+                {
+                    Write-Host "  Unable to continue, exiting."
+                    Return $False
+                }
+            
+            } while ($deleteDir -notmatch "[Y]")
+        }
+
+        Remove-Item -Recurse -Force $DirectoryToRemove
+    }
+
+    Return $True
+}
+
 Write-Host ' '
 Write-Host 'Installing Calabash on Windows:'
 Write-Host " "
@@ -16,55 +41,71 @@ if ([String]::IsNullOrWhiteSpace($androidHome))
 }
 else 
 {
-	Write-Host "  "
 	Write-Host "  Detected the Android SDK at $androidHome."
 }
 Write-Host "  "
 
-$calabashDir = "$env:USERPROFILE\calabash\"
-if (Test-Path $calabashDir)
+# STEP 3: Create the Calabash directory if required.
+$calabashDir = "$env:USERPROFILE\calabash"
+if (!(Test-Path $calabashDir)) 
 {
-	Write-Host " "
-	Write-Host "The directory $calabashDir already exists - aborting install."
-	Write-Host "If you want to run this script again, please delete that directory."
-	Write-Host " "
-}
-else 
-{
-	# STEP 3: Create the Calabash directory.
 	Write-Host "  Creating the Calabash directory at $calabashDir."	
 	New-Item $calabashDir -ItemType directory | Out-Null
 	Write-Host " "
-
-	# STEP 4: Download the SSL Certificate and set the SSL_CERT_FILE 
-	# environment variable for the process.
-	$cacertFile = "$calabashDir\cacert.pem"
-	Write-Host "  Downloading SSL certificate to $cacertFile."
-	Invoke-WebRequest 'http://curl.haxx.se/ca/cacert.pem' -OutFile $cacertFile
-	Write-Host " "
-
-	Write-Host "  Set the environment variable SSL_CERT_FILE=$cacertFile."
-	[Environment]::SetEnvironmentVariable("SSL_CERT_FILE", $cacertFile, "user")
-	[Environment]::SetEnvironmentVariable("SSL_CERT_FILE", $cacertFile, "process")
-	Write-Host " "
-
-	# STEP 5: Update the version of RubyGems 
-	Write-Host "  Performing a system update of RubyGems:"
-	& "gem" "update" "--system"
-	Write-Host " "
-
-	# STEP 6: Install the gems
-	Write-Host "    Installing ffi..."
-	& "gem" "install" "ffi" "--platform=ruby" "--no-ri" "--no-rdoc"
-	Write-Host " "
-	
-	Write-Host "    Installing xamarin-test-cloud..."
-	& "gem" "install" "xamarin-test-cloud" "--platform=ruby"  "--no-ri" "--no-rdoc"
-	Write-Host " "
-
-	Write-Host "    Installing calabash-android..."
-	& "gem" "install" "calabash-android" "--platform=ruby"  "--no-ri" "--no-rdoc"
-	Write-Host " "
-
-	Write-Host "Finished installing Calabash on Windows."
 }
+
+# STEP 4: Removing any existing Certificates directory.
+$cacertDir = "$calabashDir\certs"
+if (!(Remove-Directory -DirectoryToRemove $cacertDir))
+{
+    Exit
+}
+
+# STEP 5: Create a new Certificates directory.
+Write-Host "  Creating the Calabash cert directory at $cacertDir."	
+New-Item $cacertDir -ItemType directory | Out-Null
+Write-Host " "
+
+# STEP 6: Download the SSL Certificate and set the SSL_CERT_FILE 
+# environment variable for the process.
+$cacertFile = "$cacertDir\cacert.pem"
+Write-Host "  Downloading SSL certificate to $cacertFile."
+Invoke-WebRequest 'http://curl.haxx.se/ca/cacert.pem' -OutFile $cacertFile
+Write-Host " "
+
+Write-Host "  Set the environment variable SSL_CERT_FILE=$cacertFile."
+[Environment]::SetEnvironmentVariable("SSL_CERT_FILE", $cacertFile, "user")
+[Environment]::SetEnvironmentVariable("SSL_CERT_FILE", $cacertFile, "process")
+Write-Host " "
+
+# STEP 7: Remove any existing Gems directory.
+$gemsDir = "$calabashDir\gems"
+if (!(Remove-Directory -DirectoryToRemove $gemsDir))
+{
+    Exit
+}
+
+# STEP 8: Create the Gems directory.
+Write-Host "  Creating the Calabash gems directory at $gemsDir."
+New-Item $gemsDir -ItemType directory | Out-Null
+Write-Host " "
+
+# STEP 9: Update the version of RubyGems 
+Write-Host "  Performing a system update of RubyGems:"
+& "gem" "update" "--system"
+Write-Host " "
+
+# STEP 10: set the GEN_HOME and GEN_PATH environment variables.
+$Env:GEM_HOME = $gemsDir;
+$Env:GEM_PATH = $gemsDir;
+
+# STEP 11: Install the gems
+Write-Host "    Installing xamarin-test-cloud..."
+& "gem" "install" "xamarin-test-cloud" "--platform=ruby"  "--no-document"
+Write-Host " "
+
+Write-Host "    Installing calabash-android..."
+& "gem" "install" "calabash-android" "--platform=ruby"  "--no-document"
+Write-Host " "
+
+Write-Host "Finished installing Calabash on Windows."


### PR DESCRIPTION
- don't remove $USER/calabash
- use gems and certs sub-directories of $USER/calabash
- don't install ffi (no longer required by xamarin-test-cloud gem)

- [ ] Needs review by @topgenorth 
- [ ] Needs documentation update (issue created)