### PR TITLE
Update sandbox gemfiles for Calabash iOS/Android and xamarin-test-cloud

### DIFF
--- a/Gemfile.OSX
+++ b/Gemfile.OSX
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "calabash-cucumber", ">= 0.17.0", "< 1.0"
-gem "calabash-android", ">= 0.5.15", "< 1.0"
-gem "xamarin-test-cloud", "~> 1.0"
+gem "calabash-cucumber", ">= 0.18.1", "< 1.0"
+gem "calabash-android", ">= 0.6.0", "< 1.0"
+gem "xamarin-test-cloud", "2.0.0.pre2"

--- a/Gemfile.Windows
+++ b/Gemfile.Windows
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "calabash-android", ">= 0.5.15", "< 1.0"
-gem "xamarin-test-cloud", "~> 2.0"
+gem "calabash-android", ">= 0.6.0", "< 1.0"
+gem "xamarin-test-cloud", "2.0.0.pre2"


### PR DESCRIPTION
### Motivation

Completes **Update Calabash sandbox to include latest versions of Calabash** [#125](https://github.com/xamarinhq/test-cloud-frameworks/issues/125)

* calabash-cucumber => 0.18.1
* calabash-android => 0.6.0
* xamarin-test-cloud => 2.0.0.pre2

The controversial bit here is that we are transitioning xamarin-test-cloud 2.0.0.pre2.  There are a couple of reasons:

1. It works on Windows; 1.x does not work on Windows.
2. RestClient has been updated and now native extensions (ucf) are _not_ building on MacOS.

I have been using 2.0.0.pre2 for more than a month on the Calabash iOS test apps without incident.

@krukow I think you probably want to hear about this and approve.

- [x] @krukow approves of 2.0.0.pre2

We need to coordinate the merge of this PR with uploads to S3.

- [x] Upload MacOS gems to S3 **Ready to upload** @jmoody
- [x] Upload Windows gems to S3 **Ready to upload** @jmoody