### PR TITLE
OSX: update to 0.19.1

### DIFF
--- a/Gemfile.OSX
+++ b/Gemfile.OSX
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gem "calabash-cucumber", ">= 0.19.1", "< 1.0"
 gem "calabash-android", ">= 0.6.0", "< 1.0"
-gem "xamarin-test-cloud", "2.0.0.pre4"
+gem "xamarin-test-cloud", "2.0.0.pre5"

--- a/Gemfile.OSX
+++ b/Gemfile.OSX
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "calabash-cucumber", ">= 0.19.0", "< 1.0"
+gem "calabash-cucumber", ">= 0.19.1", "< 1.0"
 gem "calabash-android", ">= 0.6.0", "< 1.0"
 gem "xamarin-test-cloud", "2.0.0.pre4"

--- a/bin/publish/osx.sh
+++ b/bin/publish/osx.sh
@@ -27,16 +27,8 @@ function validate_cmd {
 banner "Updating Calabash Sandbox Gems"
 info "If you're not a maintainer, don't run this script!"
 
-VERSION_LINE=`cat calabash-sandbox | grep SCRIPT_VERSION=`
-VERSION=`echo $VERSION_LINE | cut -d= -f2 | cut -d\" -f2 | cut -d\" -f1`
-MAJOR=`echo $VERSION | cut -d. -f1`
-MINOR=`echo $VERSION | cut -d. -f2`
-SUB=`echo $VERSION | cut -d. -f3`
-SUB=$(($SUB + 1))
-NEW_VERSION="$MAJOR.$MINOR.$SUB"
-banner "Updating sandbox version to $NEW_VERSION"
-
-sed -i .bak "s/${VERSION}/${NEW_VERSION}/" calabash-sandbox
+# Create a reference to the ./calabash-sandbox script.
+SANDBOX_SCRIPT="${PWD}/calabash-sandbox"
 
 info "Retrieving Gemfile"
 SANDBOX="${HOME}/.calabash/sandbox"

--- a/bin/publish/osx.sh
+++ b/bin/publish/osx.sh
@@ -48,6 +48,10 @@ validate_cmd $? "copying Gemfile.OSX" 10
 cd "${SANDBOX}"
 GEMS_DIR=Gems
 
+info "Installing the Latest Lersion of Bundler"
+gem install bundler
+echo
+
 info "Installing Gems"
 bundle update
 echo

--- a/bin/publish/osx.sh
+++ b/bin/publish/osx.sh
@@ -40,13 +40,16 @@ sed -i .bak "s/${VERSION}/${NEW_VERSION}/" calabash-sandbox
 
 info "Retrieving Gemfile"
 SANDBOX="${HOME}/.calabash/sandbox"
-cp "./Gemfile.OSX" "${SANDBOX}/Gemfile"
-
-validate_cmd $? "copying Gemfile.OSX" 10
 
 if [ ! -d "${SANDBOX}" ]; then
   error "Sandbox dir does note exist! Make sure you have a sandbox installation first." 11
 fi
+
+info "Updating Gemfile and Gemfile.lock"
+cp "./Gemfile.OSX" "${SANDBOX}/Gemfile"
+
+validate_cmd $? "copying Gemfile.OSX" 10
+
 cd "${SANDBOX}"
 GEMS_DIR=Gems
 

--- a/bin/publish/osx.sh
+++ b/bin/publish/osx.sh
@@ -12,6 +12,9 @@ function info {
   echo "$(tput setaf 2)INFO: $1$(tput sgr0)"
 }
 
+function version {
+  echo "$(tput setaf 3)$1: $2$(tput sgr0)"
+}
 function error {
   echo "$(tput setaf 1)ERROR: $1$(tput sgr0)"
   exit $2
@@ -46,8 +49,16 @@ cd "${SANDBOX}"
 GEMS_DIR=Gems
 
 info "Installing Gems"
-calabash-sandbox update
-validate_cmd $? "installing gems" 3
+bundle update
+echo
+
+info "Done! Now the sandbox contains:"
+IOS=`calabash-ios version | tr -d '\n'`
+DROID=`calabash-android version | tr -d '\n'`
+XTC=`test-cloud version | tr -d '\n'`
+version "      calabash-ios" $IOS
+version "  calabash-android" $DROID
+version "xamarin-test-cloud" $XTC
 
 info "Zipping Gems"
 zip -qr CalabashGems.zip $GEMS_DIR

--- a/bin/test/run.sh
+++ b/bin/test/run.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
+rm -rf ~/.calabash/sandbox
 bin/test/sandbox-test.sh
 

--- a/bin/test/sandbox-test.sh
+++ b/bin/test/sandbox-test.sh
@@ -24,7 +24,7 @@ cd "${TMP_DIR}"
 
 set -e
 
-IOS_EXPECTED_VERSION="0.19.0"
+IOS_EXPECTED_VERSION="0.19.1"
 DROID_EXPECTED_VERSION="0.7.3"
 
 DROID=$( { echo "calabash-android version >&2" |  calabash-sandbox 1>/dev/null; } 2>&1)

--- a/bin/test/sandbox-test.sh
+++ b/bin/test/sandbox-test.sh
@@ -59,36 +59,3 @@ if [ "${gem_home}" != "${HOME}/.calabash/sandbox/Gems" ]; then
   exit 4
 fi
 
-if [ ! -z "${TRAVIS}" ]; then
-  echo "Integration tests don't run on Travis."
-  echo "Done!"
-  exit 0
-fi
-
-git clone https://github.com/calabash/calabash-ios-server.git
-
-cd calabash-ios-server
-bundle install
-make app-cal
-
-mv Products/test-target/app-cal/LPTestTarget.app \
-  ../cucumber
-
-cd ../cucumber
-
-mkdir -p results
-
-# Fails silently.
-#
-# [ENV] cucumber [args]
-# echo "$?" > exit.out
-#
-# exit.out is always 0
-#
-# Will have to rely on post-processing of results/cucumber.json
-calabash-sandbox <<EOF
-APP=./LPTestTarget.app cucumber --format pretty --format json -o results/cucumber.json 2>&1 | tee stdout.log
-echo $? > exit_code.log
-exit
-EOF
-

--- a/bin/test/sandbox-test.sh
+++ b/bin/test/sandbox-test.sh
@@ -29,12 +29,13 @@ set -e
 
 ./install-osx.sh
 
-
 IOS_EXPECTED_VERSION="0.19.1"
 DROID_EXPECTED_VERSION="0.7.3"
+XTC_EXPECTED_VERSION="2.0.0.pre5"
 
 DROID=$( { echo "calabash-android version >&2" |  calabash-sandbox 1>/dev/null; } 2>&1)
 IOS=$( { echo "calabash-ios version >&2" | calabash-sandbox 1>/dev/null; } 2>&1)
+XTC=$( { echo "test-cloud version >&2" | calabash-sandbox 1>/dev/null; } 2>&1)
 gem_home=$( { echo "echo \$GEM_HOME >&2" | calabash-sandbox 1>/dev/null; } 2>&1)
 
 echo "Testing calabash-android version"
@@ -47,10 +48,15 @@ if [ "${IOS}" != "${IOS_EXPECTED_VERSION}" ]; then
   error "calabash-ios version ($IOS) should be $IOS_EXPECTED_VERSION" 2
 fi
 
+echo "Testing test-cloud version"
+if [ "${XTC}" != "${XTC_EXPECTED_VERSION}" ]; then
+  error "test-cloud version ($XTC) should be $XTC_EXPECTED_VERSION" 3
+fi
+
 echo "Ensuring sandbox GEM_HOME properly set"
 if [ "${gem_home}" != "${HOME}/.calabash/sandbox/Gems" ]; then
   echo "Gem Home should be ${HOME}/.calabash/sandbox/Gems; Got $gem_home"
-  exit 3
+  exit 4
 fi
 
 if [ ! -z "${TRAVIS}" ]; then

--- a/bin/test/sandbox-test.sh
+++ b/bin/test/sandbox-test.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+function error {
+  echo "$(tput setaf 1)ERROR: $1$(tput sgr0)"
+  exit $2
+}
+
 # In the absence of a --no-input option, we need to clear an existing sandbox
 # before we test on Jenkins, otherwise the test will block waiting for input.
 #
@@ -33,14 +38,12 @@ gem_home=$( { echo "echo \$GEM_HOME >&2" | calabash-sandbox 1>/dev/null; } 2>&1)
 
 echo "Testing calabash-android version"
 if [ "${DROID}" != "${DROID_EXPECTED_VERSION}" ]; then
-  echo "calabash-android version ($DROID) should be $DROID_EXPECTED_VERSION"
-  exit 1
+  error "calabash-android version ($DROID) should be $DROID_EXPECTED_VERSION" 1
 fi
 
 echo "Testing calabash-ios version"
 if [ "${IOS}" != "${IOS_EXPECTED_VERSION}" ]; then
-  echo "calabash-ios version ($IOS) should be $IOS_EXPECTED_VERSION"
-  exit 2
+  error "calabash-ios version ($IOS) should be $IOS_EXPECTED_VERSION" 2
 fi
 
 echo "Ensuring sandbox GEM_HOME properly set"

--- a/bin/test/sandbox-test.sh
+++ b/bin/test/sandbox-test.sh
@@ -87,6 +87,8 @@ mkdir -p results
 #
 # Will have to rely on post-processing of results/cucumber.json
 calabash-sandbox <<EOF
-APP=./LPTestTarget.app cucumber --format pretty --format json -o results/cucumber.json
+APP=./LPTestTarget.app cucumber --format pretty --format json -o results/cucumber.json 2>&1 | tee stdout.log
+echo $? > exit_code.log
 exit
 EOF
+

--- a/bin/test/sandbox-test.sh
+++ b/bin/test/sandbox-test.sh
@@ -25,9 +25,10 @@ cp -r bin/test/cucumber "${TMP_DIR}"
 
 cd "${TMP_DIR}"
 
+set -e
+
 ./install-osx.sh
 
-set -e
 
 IOS_EXPECTED_VERSION="0.19.1"
 DROID_EXPECTED_VERSION="0.7.3"


### PR DESCRIPTION
### Motivation

0.19.1 has been released.

There is a chicken-and-egg problem with the tests.

1. In order for the tests to pass, the correct gems _must be published to AWS_.
2. The `bin/publish/osx.sh` reads the Gemfile.OSX gem file from the GitHub master.  This means that you can't publish the correct gems without merging the pull request first.  See Step 1.

@sapieneptus Is the intent to publish the latest gems to AWS before submitting a pull-request?

If so, I have an idea for how to make this happen.  Let me know and I will append this PR.
