### PR TITLE
Update sandbox to xamarin-test-cloud 2.0.0

### DIFF
--- a/Gemfile.OSX
+++ b/Gemfile.OSX
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gem "calabash-cucumber", ">= 0.19.1", "< 1.0"
 gem "calabash-android", ">= 0.6.0", "< 1.0"
-gem "xamarin-test-cloud", "2.0.0.pre5"
+gem "xamarin-test-cloud", "2.0.0"

--- a/Gemfile.Windows
+++ b/Gemfile.Windows
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
 gem "calabash-android", ">= 0.6.0", "< 1.0"
-gem "xamarin-test-cloud", "2.0.0.pre2"
+gem "xamarin-test-cloud", "2.0.0"

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Test Cloud, so you don't need to worry about ruby compatibilities.
 
 Calabash Sandbox requires one of the following operating systems:
 - OSX Yosemite
-- OSX El Capitan 
+- OSX El Capitan
 - Windows 10
 
-The sandbox is not officially supported on other OS versions. 
+The sandbox is not officially supported on other OS versions.
 
 ### Installation
 

--- a/bin/publish/osx.sh
+++ b/bin/publish/osx.sh
@@ -48,12 +48,15 @@ validate_cmd $? "copying Gemfile.OSX" 10
 cd "${SANDBOX}"
 GEMS_DIR=Gems
 
-info "Installing the Latest Lersion of Bundler"
-gem install bundler
+# We need a clean install
+rm -rf "${GEMS_DIR}"
+
+info "Installing the latest version of bundler"
+GEM_HOME="${GEMS_DIR}" GEM_PATH="${GEMS_DIR}" gem install bundler
 echo
 
 info "Installing Gems"
-bundle update
+GEM_HOME="${GEMS_DIR}" GEM_PATH="${GEMS_DIR}" bundle update
 echo
 
 info "Done! Now the sandbox contains:"
@@ -65,6 +68,7 @@ version "  calabash-android" $DROID
 version "xamarin-test-cloud" $XTC
 
 info "Zipping Gems"
+rm -rf CalabashGems.zip
 zip -qr CalabashGems.zip $GEMS_DIR
 validate_cmd $? "zipping gems" 4
 

--- a/bin/publish/osx.sh
+++ b/bin/publish/osx.sh
@@ -37,7 +37,7 @@ info "Retrieving Gemfile"
 SANDBOX="${HOME}/.calabash/sandbox"
 
 if [ ! -d "${SANDBOX}" ]; then
-  error "Sandbox dir does note exist! Make sure you have a sandbox installation first." 11
+  error "Sandbox does not exist! Make sure you have a sandbox installation first." 11
 fi
 
 info "Updating Gemfile and Gemfile.lock"

--- a/bin/test/sandbox-test.sh
+++ b/bin/test/sandbox-test.sh
@@ -31,7 +31,7 @@ set -e
 
 IOS_EXPECTED_VERSION="0.19.1"
 DROID_EXPECTED_VERSION="0.7.3"
-XTC_EXPECTED_VERSION="2.0.0.pre5"
+XTC_EXPECTED_VERSION="2.0.0"
 
 DROID=$( { echo "calabash-android version >&2" |  calabash-sandbox 1>/dev/null; } 2>&1)
 IOS=$( { echo "calabash-ios version >&2" | calabash-sandbox 1>/dev/null; } 2>&1)

--- a/install-osx.sh
+++ b/install-osx.sh
@@ -59,7 +59,7 @@ rm "CalabashGems.zip"
 echo "source 'https://rubygems.org'" > "${SANDBOX}/Gemfile"
 echo "gem 'calabash-cucumber', '>= 0.17.0', '< 1.0'" >> "${SANDBOX}/Gemfile"
 echo "gem 'calabash-android', '>= 0.5.15', '< 1.0'" >> "${SANDBOX}/Gemfile"
-echo "gem 'xamarin-test-cloud', '~> 1.0'" >> "${SANDBOX}/Gemfile"
+echo "gem 'xamarin-test-cloud', '~> 2.0'" >> "${SANDBOX}/Gemfile"
 
 #Download the Sandbox Script
 echo "Preparing sandbox..."

--- a/install-osx.sh
+++ b/install-osx.sh
@@ -32,9 +32,10 @@ mkdir -p "${HOME}/.calabash/sandbox/Rubies"
 #Download Ruby
 echo "Preparing Ruby ${CALABASH_RUBY_VERSION}..."
 
+URL="https://s3-eu-west-1.amazonaws.com/calabash-files/${CALABASH_RUBY_VERSION}.zip"
 curl -o \
   "${CALABASH_RUBY_VERSION}.zip" \
-  --progress-bar https://s3-eu-west-1.amazonaws.com/calabash-files/${CALABASH_RUBY_VERSION}.zip
+  --progress-bar "${URL}"
 
 unzip -qo "${CALABASH_RUBY_VERSION}.zip" -d "${CALABASH_RUBIES_HOME}"
 rm "${CALABASH_RUBY_VERSION}.zip"


### PR DESCRIPTION
### Motivation

Progress on:

* [Jira: Release 2.0.0 of test-cloud-command-line](https://xamarin.atlassian.net/browse/TCFW-35)
* [Jira: update sandbox to xamarin-test-cloud 2.0.0](https://xamarin.atlassian.net/browse/TCFW-65)


The changes in `bin/publish/osx.sh` were required because:

1. If the sandbox/Gems directory is not deleted, stale versions of gems will be including in the CalabashGems.zip that is uploaded to S3.  
2. If there is a pre-release in sandbox/Gems directory it may or may not be replaced by 'bundle update'.


### Tasks

- [x] Windows gems uploaded
- [x] macOS gems uploaded
