### PR TITLE
OSX: exit non-zero if rbenv or rvm is already installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ Test Cloud, so you don't need to worry about ruby compatibilities.
 ## System Requirements
 
 Calabash Sandbox requires one of the following operating systems:
-- OSX Yosemite
-- OSX El Capitan
+- OSX El Cap and Sierria
 - Windows 10
 
 The sandbox is not officially supported on other OS versions.
+
+If you already have rbenv or rvm installed, then this repo is _not_ for you.
 
 ### Installation
 

--- a/calabash-sandbox
+++ b/calabash-sandbox
@@ -10,6 +10,23 @@ if [ "$(uname -s)" != "Darwin" ]; then
   exit 1
 fi
 
+is_command_in_path()
+{
+    command -v "$1" >/dev/null 2>&1
+}
+
+if is_command_in_path "rbenv"; then
+  echo "Detected that rbenv is already installed."
+  echo "You cannot use the calabash-sandbox."
+  exit 1
+fi
+
+if is_command_in_path "rvm"; then
+  echo "Detected that rvm is already installed."
+  echo "You cannot use the calabash-sandbox."
+  exit 1
+fi
+
 if [ "${1}" == "version" ]; then
   echo "Calabash sandbox version: ${SCRIPT_VERSION}"
   exit 0

--- a/install-osx.sh
+++ b/install-osx.sh
@@ -5,7 +5,24 @@ if [ "${SANDBOX_URL}" == "" ]; then
 fi
 
 if [ "$(uname -s)" != "Darwin" ]; then
-  echo "Calabash-sandbox only runs on Mac OSX"
+  echo "calabash-sandbox only runs on Mac OSX"
+  exit 1
+fi
+
+is_command_in_path()
+{
+    command -v "$1" >/dev/null 2>&1
+}
+
+if is_command_in_path "rbenv"; then
+  echo "Detected that rbenv is already installed."
+  echo "You cannot use the calabash-sandbox."
+  exit 1
+fi
+
+if is_command_in_path "rvm"; then
+  echo "Detected that rvm is already installed."
+  echo "You cannot use the calabash-sandbox."
   exit 1
 fi
 
@@ -15,7 +32,7 @@ CALABASH_RUBY_VERSION="2.3.1"
 SANDBOX="${HOME}/.calabash/sandbox"
 CALABASH_SANDBOX="calabash-sandbox"
 
-#Don't auto-overwrite the sandbox if it already exists
+# Don't auto-overwrite the sandbox if it already exists
 if [ -d "${SANDBOX}" ]; then
   echo "Sandbox already exists!"
   echo "Please delete the directory:"


### PR DESCRIPTION
### Motivation

I noticed that some users are trying to using the calabash-sandbox when they have rbenv or rvm installed.  We cannot afford to maintain and test a sandbox in these environments.

If rbenv or rvm is available, exit non-zero with a message.

The downside is that we cannot test on Travis or Jenkins.

### Test

```
### rvm
$ curl -sSL https://rawgit.com/calabash/install/9e7b4c44fb1c5d84f16acae870a9487ad5437f9e/install-osx.sh | bash
Detected that rvm is already installed.
You cannot use the calabash-sandbox.

### rbenv
$  curl -sSL https://rawgit.com/calabash/install/9e7b4c44fb1c5d84f16acae870a9487ad5437f9e/install-osx.sh | bash
Detected that rbenv is already installed.
You cannot use the calabash-sandbox.
```